### PR TITLE
feat: added json schemas for all models to improve dev experience

### DIFF
--- a/fixtures/allegiances.yaml
+++ b/fixtures/allegiances.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../schema/allegiances.schema.json
+
 - model: Allegiance
   rows:
     - id: stormcast_eternals

--- a/fixtures/alliances.yaml
+++ b/fixtures/alliances.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../schema/alliances.schema.json
+
 - model: GrandAlliance
   rows:
     - id: order

--- a/fixtures/cities.yaml
+++ b/fixtures/cities.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../schema/cities.schema.json
+
 - model: City
   rows:
     - id: anvilgard

--- a/fixtures/units.yaml
+++ b/fixtures/units.yaml
@@ -1,9 +1,11 @@
+# yaml-language-server: $schema=../schema/units.schema.json
+
 - model: Unit
   rows:
     - id: lord_celestant
       name: Lord-Celestant
       grand_alliance: order
-      move: 5in
+      move: 5"
       description: A mighty warrior and leader of the Stormcast Eternals, wielding a powerful weapon and inspiring nearby units.
       save: 3
       bravery: 9
@@ -24,25 +26,25 @@
       magic: []
       damage_table:
         - wound_track_position: 0
-          move: 5in
+          move: 5"
           min_wounds_suffered: 0
       melee_weapons:
         - name: Celestine Hammer
-          range: '1'
+          range: 1"
           attacks: '4+'
           to_hit: '3+'
           to_wound: '3+'
           rend: '-1'
           damage: 'D3'
         - name: Stormbound Blade
-          range: '1'
+          range: 1"
           attacks: '1'
           to_hit: '3+'
           to_wound: '4+'
           rend: '-1'
           damage: '2'
         - name: Great Claws
-          range: '1'
+          range: 1"
           attacks: '2'
           to_hit: '3+'
           to_wound: '3+'
@@ -52,7 +54,7 @@
     - id: liberators
       name: Liberators
       grand_alliance: order
-      move: 5in
+      move: 5"
       description: Mighty warriors armed with powerful warhammers and shields, forming the backbone of the Stormcast Eternals forces.
       save: 4
       bravery: 7
@@ -71,11 +73,11 @@
       magic: []
       damage_table:
         - wound_track_position: 0
-          move: 5in
+          move: 5"
           min_wounds_suffered: 0
       melee_weapons:
         - name: Warhammer
-          range: '1'
+          range: 1"
           attacks: '1+'
           to_hit: '4+'
           to_wound: '3+'

--- a/fixtures/warscrolls.yaml
+++ b/fixtures/warscrolls.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../schema/warscrolls.schema.json
+
 - model: Warscroll
   rows:
     - id: helstorm_rocket_battery

--- a/schema/allegiances.schema.json
+++ b/schema/allegiances.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "$id": "https://aos-api.com/schema/allegiances.schema.json",
+  "title": "Allegiances",
+  "type": "array",
+  "items": {
+    "properties": {
+      "model": {
+        "type": "string"
+      },
+      "rows": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["id", "name"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z_]+$"
+            },
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "grand_alliance": {
+              "type": "string",
+              "pattern": "^[a-z_]+$",
+              "enum": ["order", "chaos", "destruction", "death"]
+            },
+            "mortal_realm": {
+              "type": "string",
+              "pattern": "^[a-z_]+$",
+              "enum": [
+                "aqshy",
+                "azyr",
+                "chamon",
+                "ghur",
+                "ghyran",
+                "hysh",
+                "shyish",
+                "ulgu"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/alliances.schema.json
+++ b/schema/alliances.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "$id": "https://aos-api.com/schema/alliances.schema.json",
+  "title": "Alliances",
+  "type": "array",
+  "items": {
+    "properties": {
+      "model": {
+        "type": "string"
+      },
+      "rows": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["id", "name"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z_]+$"
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the grand alliance."
+            },
+            "description": {
+              "type": "string",
+              "description": "A description of the grand alliance."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/cities.schema.json
+++ b/schema/cities.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "$id": "https://aos-api.com/schema/cities.schema.json",
+  "title": "Cities",
+  "type": "array",
+  "items": {
+    "properties": {
+      "model": {
+        "type": "string"
+      },
+      "rows": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["id", "name"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z_]+$"
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the city."
+            },
+            "description": {
+              "type": "string",
+              "description": "A description of the city."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/strategies.schema.json
+++ b/schema/strategies.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "$id": "https://aos-api.com/schema/strategies.schema.json",
+  "title": "Strategies",
+  "type": "array",
+  "items": {
+    "properties": {
+      "model": {
+        "type": "string"
+      },
+      "rows": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["id", "name"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z_]+$"
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the Grand Strategy."
+            },
+            "description": {
+              "type": "string",
+              "description": "A description of the Grand Strategy."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/units.schema.json
+++ b/schema/units.schema.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "$id": "https://aos-api.com/schema/units.schema.json",
+  "title": "Units",
+  "type": "array",
+  "items": {
+    "properties": {
+      "model": {
+        "type": "string"
+      },
+      "rows": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["id", "name"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z_]+$"
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the unit."
+            },
+            "description": {
+              "type": "string",
+              "description": "A description of the unit."
+            },
+            "grand_alliance": {
+              "type": "string",
+              "description": "The Grand Alliance the unit belongs to.",
+              "pattern": "^[a-z_]+$",
+              "enum": ["order", "chaos", "destruction", "death"]
+            },
+            "move": {
+              "type": "string",
+              "description": "The unit's move characteristics in inches.",
+              "pattern": "[0-9]+\""
+            },
+            "save": {
+              "type": "number"
+            },
+            "bravery": {
+              "type": "number"
+            },
+            "models": {
+              "type": "number"
+            },
+            "points": {
+              "type": "number"
+            },
+            "wounds": {
+              "type": "number"
+            },
+            "abilities": {
+              "type": "array",
+              "description": "The abilities the unit has.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the ability."
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "keywords": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "command_abilities": {
+              "type": "array",
+              "description": "The command abilities the unit has.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "magic": {
+              "type": "array",
+              "description": "The magic abilities the unit has.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "damage_table": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "wound_track_position": {
+                    "type": "number"
+                  },
+                  "move": {
+                    "type": "string",
+                    "pattern": "[0-9]+\""
+                  },
+                  "min_wounds_suffered": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "melee_weapons": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "range": {
+                    "type": "string",
+                    "pattern": "[0-9]+\""
+                  },
+                  "attacks": {
+                    "type": "string",
+                    "pattern": "^[0-9+-D]+$"
+                  },
+                  "to_hit": {
+                    "type": "string"
+                  },
+                  "to_wound": {
+                    "type": "string"
+                  },
+                  "rend": {
+                    "type": "string"
+                  },
+                  "damage": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "missile_weapons": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "range": {
+                    "type": "string",
+                    "pattern": "[0-9]+\""
+                  },
+                  "attacks": {
+                    "type": "string",
+                    "pattern": "^[0-9+-D]+$"
+                  },
+                  "to_hit": {
+                    "type": "string"
+                  },
+                  "to_wound": {
+                    "type": "string"
+                  },
+                  "rend": {
+                    "type": "string"
+                  },
+                  "damage": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/warscrolls.schema.json
+++ b/schema/warscrolls.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "$id": "https://aos-api.com/schema/warscrolls.schema.json",
+  "title": "Warscrolls",
+  "type": "array",
+  "items": {
+    "properties": {
+      "model": {
+        "type": "string"
+      },
+      "rows": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["id", "name", "size", "points"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z_]+$"
+            },
+            "name": {
+              "type": "string"
+            },
+            "allegiance_id": {
+              "type": "string"
+            },
+            "grand_alliance_id": {
+              "type": "string",
+              "enum": ["order", "chaos", "destruction", "death"]
+            },
+            "size": {
+              "type": "number"
+            },
+            "points": {
+              "type": "number"
+            },
+            "battlefield_role": {
+              "type": "string"
+            },
+            "notes": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Changes

Adding JSON schemas to improve the discoverability of model fields when adding data to the fixtures. Includes pattern checks, required fields, and a few field descriptions. This works out of the box if you're editing the fixtures in VSCode.

- Adds the following JSON schemas for each of the data models
  - schema/allegiances.schema.json
  - schema/alliances.schema.json
  - schema/cities.schema.json
  - schema/strategies.schema.json
  - schema/units.schema.json
  - schema/warscrolls.schema.json